### PR TITLE
docs(dutch): lock the language rule (#84), and rescue the #82/#83 docs onto main

### DIFF
--- a/docs/dutch/CONTEXT.md
+++ b/docs/dutch/CONTEXT.md
@@ -1,11 +1,11 @@
 # Dutch learning journey
 
-A repo-native, agent-run Dutch practice aimed at Staatsexamen NT2, published on the site. The vocabulary below is this context's ubiquitous language: these words appear in the skill, in Astro schemas, in URLs, and in every conversation about the work. Taxonomy locked by [#82](https://github.com/atilileri/atilileri.github.io/issues/82); the map is [#74](https://github.com/atilileri/atilileri.github.io/issues/74).
+A repo-native, agent-run Dutch practice aimed at Staatsexamen NT2, published on the site. The vocabulary below is this context's ubiquitous language: these words appear in the skill, in Astro schemas, in URLs, and in every conversation about the work. Taxonomy locked by [#82](https://github.com/atilileri/atilileri.github.io/issues/82); the language rule by [#84](https://github.com/atilileri/atilileri.github.io/issues/84); the map is [#74](https://github.com/atilileri/atilileri.github.io/issues/74).
 
 ## Language
 
 **Lesson**:
-A durable teaching artifact — exposition on one thing, sized to about ten minutes of reading. It contains no prompts and bears no answers. One file, mixed Turkish and English.
+A durable teaching artifact — exposition on one thing, sized to about ten minutes of reading. It contains no prompts and bears no answers. One file, written in Turkish prose, quoting Dutch and English words.
 _Avoid_: Explainer, chapter, module
 
 **Session**:
@@ -13,7 +13,7 @@ A dated record of one invocation — what was taught, what was asked, and what t
 _Avoid_: Iteration, lesson (when the event is meant), practice log
 
 **Item**:
-One lexical or grammatical thing held as sibling fields (`nl` / `tr` / `en`), in a single central inventory. The unit the scheduler acts on. Never embedded in a Lesson — a Lesson references Items by id.
+One lexical or grammatical thing held as sibling fields (`nl` / `tr` / `en`, plus the optional `bridge` and `trap`), in a single central inventory. The unit the scheduler acts on. Never embedded in a Lesson — a Lesson references Items by id.
 _Avoid_: Note, card, word, entry
 
 **Direction**:
@@ -56,3 +56,11 @@ _Avoid_: Use-case, situation card, role-play
 **Theme**:
 The subject a Session is dressed in. It is chosen by a fixed priority — the theme the learner types, then an open intake issue, then a Scenario. A Theme decorates the next Plan objective and never replaces it.
 _Avoid_: Topic, context, subject
+
+**Bridge**:
+A resemblance that helps — a Dutch word an English or Turkish word already explains. It is an optional field on an Item, written in Turkish prose that quotes the foreign word: *"Hollandaca `vriend` ve İngilizce `friend` kelimeleri aynı kökten gelir."* A Bridge that claims a shared origin cites a source; one that claims only a resemblance needs none.
+_Avoid_: Cognate note, hint, mnemonic
+
+**Trap**:
+A resemblance that misleads — an intuition from English or Turkish that produces wrong Dutch the learner would not notice. It is an optional field on an Item and names its direction, `en` or `tr`. An Item carries at most one Trap, and a Lesson shows at most three. A difference the learner knows they are guessing at is taught, not a Trap.
+_Avoid_: False friend, gotcha, warning, flag

--- a/docs/dutch/CONTEXT.md
+++ b/docs/dutch/CONTEXT.md
@@ -44,3 +44,15 @@ _Avoid_: Dictionary, lexicon, vocabulary list — the lexicon belongs to Items.
 
 **Reference**:
 A compressed, topic-shaped cheat sheet — a conjugation table, a word-order rule — revised in place rather than written once per Session.
+
+**Profile**:
+The standing description of who the learner is — work, life, sport, taste, people, and Dutch so far. Public, current-state, and revised in place. It shapes the colour of every Session; it never decides what is taught.
+_Avoid_: Bio, persona, about-me, memory
+
+**Scenario**:
+A recurring situation in the learner's life that needs Dutch, held in one library. It links to Plan objectives and carries a register; it never states an objective of its own. A Scenario is never consumed.
+_Avoid_: Use-case, situation card, role-play
+
+**Theme**:
+The subject a Session is dressed in. It is chosen by a fixed priority — the theme the learner types, then an open intake issue, then a Scenario. A Theme decorates the next Plan objective and never replaces it.
+_Avoid_: Topic, context, subject

--- a/docs/dutch/adr/0001-the-profile-is-public.md
+++ b/docs/dutch/adr/0001-the-profile-is-public.md
@@ -1,0 +1,63 @@
+# ADR 0001 — The learner Profile is public, and the agent never writes it silently
+
+**Status**: Accepted
+**Date**: 2026-09-02
+**Scope**: `docs/dutch` — the Profile at `docs/dutch/PROFILE.md`, the Scenario
+library at `docs/dutch/SCENARIOS.md`, and the skill that reads and grows them
+**Spec**: [#83](https://github.com/atilileri/atilileri.github.io/issues/83), under map [#74](https://github.com/atilileri/atilileri.github.io/issues/74)
+
+## Context
+
+The Dutch journey personalises every Session from a **Profile** — a standing
+description of who the learner is: work, life in the Netherlands, sport, taste in
+film and television, the people they speak Dutch with, and what they already
+manage in Dutch. The agent grows it as it learns things during a Session.
+
+This is the most personal artifact in the system, and map #74 locks *everything
+public*. So the Profile is a public document of what one named person does, likes,
+and avoids — published on a personal site, in a repo with public history.
+
+An obvious alternative existed and was rejected. Claude Code already keeps an
+**auto-memory** directory for this project, outside the repo, private and
+machine-local. It is loaded every session automatically. Putting the Profile there
+would have made the whole question disappear.
+
+Two facts weakened the privacy objection. The site **already publishes this
+person** — `src/pages/cv.astro` runs to 751 lines, `src/pages/now.astro` states
+the Dutch B1 goal outright, and the `sports` collection carries the rest. And the
+journey's premise is learning in public: the Lessons and Sessions are published, so
+a private Profile would be the one hidden input behind public output.
+
+## Decision
+
+**The Profile is public, committed, and the single source of truth. Auto-memory
+holds a pointer to it and nothing else.**
+
+Three rules make that safe, and they stand or fall together:
+
+1. **An exclusion list lives in the file's own header** — no home address, no
+   employer-confidential work detail, no health data, no named family members, no
+   birth dates, and no detail of the immigration case beyond the exam goal the NOW
+   page already states. It sits in the file, not in a skill, so a stranger reading
+   the Profile sees the boundary and a future agent applies it without asking.
+2. **The agent never writes silently.** It proposes candidate facts at the end of a
+   Session, as a short list; the learner accepts or rejects each; the write lands in
+   the same commit as the Session. A silent write to a public file is a publication.
+3. **Facts are replaced in place, never appended.** The Profile is a current-state
+   document. Git holds every past version, so an in-file supersession log would only
+   grow the public surface for no gain.
+
+## Consequences
+
+- **Auto-memory is deliberately starved for this domain.** It cannot satisfy the
+  publicness lock, cannot be reviewed by a reader, and does not survive a move to
+  another machine. Anyone tempted to "just remember that" about Dutch should write
+  to the Profile instead.
+- **Publication is irreversible.** A fact removed from the Profile stays in the
+  repo's history and in whatever a reader kept. The exclusion list is therefore a
+  gate at write time, not a cleanup to run later.
+- **The propose-then-confirm loop costs the learner attention every Session.** That
+  cost is the point. It is what keeps rule 1 enforced by a person rather than by a
+  prompt.
+- **This binds the Scenario library too.** Scenarios describe real situations in the
+  learner's life, so the same three rules apply to `docs/dutch/SCENARIOS.md`.

--- a/docs/dutch/adr/0002-turkish-prose-quoted-english.md
+++ b/docs/dutch/adr/0002-turkish-prose-quoted-english.md
@@ -1,0 +1,92 @@
+# ADR 0002 — Prose is Turkish; English appears only as a quoted word
+
+**Status**: Accepted
+**Date**: 2026-09-02
+**Scope**: `docs/dutch` — every Lesson, every Session, the Item inventory, and the
+skill that writes them
+**Spec**: [#84](https://github.com/atilileri/atilileri.github.io/issues/84), under map [#74](https://github.com/atilileri/atilileri.github.io/issues/74)
+
+## Context
+
+Map #74 locks the study experience as **Turkish-first**, and locks the Germanic
+**bridge** to English. Dutch and English are West Germanic siblings, so English
+explains Dutch vocabulary far better than Turkish does. Research
+[#78](https://github.com/atilileri/atilileri.github.io/issues/78) went further: four
+L3-acquisition models plus Hopp (2019) found that a Turkish/English bilingual
+recruits the *English* system for a Germanic L3, and it recommended English-only
+mediation. The learner overrode the exclusivity of that recommendation, not the
+finding.
+
+That left one mechanical question, and it is the one a reader feels most. A cognate
+note is inherently English-bearing. Does it sit inside Turkish prose, or as a marked
+English block? The two answers produce very different documents. Marked blocks give
+a clean seam and let English carry whole arguments. They also stop a Turkish page
+dead, several times per Lesson.
+
+A second question rode with it. `en: "brave"` says what a Dutch word means. "Looks
+like English `brave`, but means *uslu*" is a different claim that merely happens to
+involve English. Research [#79](https://github.com/atilileri/atilileri.github.io/issues/79)
+proposed `nl` / `tr` / `en` sibling fields on an Item and did not distinguish them.
+
+## Decision
+
+**The reader decides the language. An artifact the learner studies is Turkish. An
+artifact the agent reads to do its job is English. Prose is never mixed: English
+appears only as a quoted word inside a Turkish sentence.**
+
+So there are no English blocks, and no code-switched paragraphs. The bridge is
+explained in Turkish and the bridging word is quoted:
+
+> Hollandaca `vriend` ve İngilizce `friend` kelimeleri aynı kökten gelir.
+>
+> İngilizcedeki `brave` (cesur) kelimesi gibi görünür, ama *iyi, uslu* anlamına gelir.
+
+Per element:
+
+| Element | Language |
+| --- | --- |
+| Lesson exposition, grammar explanation, headings, prompt instructions | Turkish |
+| Bridge and Trap prose | Turkish, quoting the English or Dutch word |
+| Etymology story | Turkish, quoting Germanic forms verbatim |
+| The prompt itself | Dutch, or Turkish when it asks for a translation |
+| Error feedback | Turkish |
+| Glossary entry | Turkish gloss plus the Dutch term |
+| Session record | English, quoting the learner's answers verbatim |
+| Profile, Plan, Mission, Learning Record, Scenario | English |
+
+The agent converses the same way: it **teaches in Turkish**, and reports tooling
+work — file writes, git, errors — in **English**.
+
+**An Item gains two optional fields, `bridge` and `trap`**, beside `nl` / `tr` /
+`en`. A Trap names its direction, `en` or `tr`.
+
+**A Trap fires on silent wrongness, not on difference.** All three conditions must
+hold: the learner holds an intuition from Turkish or English; following it produces
+wrong Dutch; and the learner would not notice. The existence of `de` and `het` is
+taught, because the learner knows they are guessing. A Turkish speaker dropping the
+article entirely is a Trap, because nothing feels missing. Budget: one Trap per
+Item, three per Lesson. Past that the agent teaches the pattern once.
+
+**A Bridge that claims shared origin cites a source. A Bridge that claims only a
+resemblance cites none, and a Trap cites none** — a Trap asserts current meaning,
+which one dictionary look settles.
+
+## Consequences
+
+- **The Lesson is a single-language document for every purpose the site cares
+  about.** `lang: "tr"` describes it correctly, and the `blog` collection's
+  `translationId` pairing never applies, because no English twin exists and none
+  will. This is what #84 hands to
+  [#88](https://github.com/atilileri/atilileri.github.io/issues/88).
+- **The rule scales to artifacts this map has not invented.** Anything new is
+  classified by asking who reads it, not by adding a row to a table.
+- **English loses the explanatory role #78 recommended for it.** English keeps the
+  lexical work — which is where the evidence is strongest — and Turkish carries every
+  argument. If Lessons later prove hard to follow, this ADR is the thing to revisit.
+- **The source rule is asymmetric on purpose.** Invented etymology is the failure a
+  model produces most readily here, and the cheap form — "İngilizce `friend` gibi
+  görünür" — stays available when no source is at hand.
+- **Trap content is out of scope here.** This ADR fixes that the slots exist and
+  which language fills them.
+  [#87](https://github.com/atilileri/atilileri.github.io/issues/87) decides what goes
+  in them.


### PR DESCRIPTION
Resolves the grilling ticket #84 under map #74, and lands the Dutch documents that never reached `main`.

## Two commits, two jobs

**1. Carry forward.** The #82 and #83 vocabulary and ADR 0001 were sitting on `build/widget-module-contract` and `build/coding-standards` — both local only, on one machine, never pushed. One of them, the **Profile** / **Scenario** / **Theme** terms, rode inside a commit titled "move the lottery Widget into a module". This commit carries that state onto a docs branch unchanged, so the #84 work reads as a clean diff on top.

**2. The #84 decision.** Prose is Turkish; English appears only as a quoted word.

## What #84 locked

The governing rule is **the reader decides the language**: an artifact the learner *studies* is Turkish, an artifact the *agent* reads is English. It already predicted the Lesson (#82) and the Profile (#83).

The central mechanical question — inline English, or marked English blocks? — resolved **neither**. There are no English blocks and no mixed prose:

> Hollandaca `vriend` ve İngilizce `friend` kelimeleri aynı kökten gelir.

- An Item gains optional **`bridge`** and **`trap`** fields, both Turkish prose. #87 decides what fills them.
- A **Trap** fires on silent wrongness, not difference. One per Item, three per Lesson.
- A Bridge claiming **shared origin** cites a source. Nothing else does.
- Hands #88: a Lesson is single-language Turkish, so `blog`'s `translationId` never applies.

This overrides the *exclusivity* of research #78's English-mediated recommendation, not its finding. ADR 0002 records the trade-off.

## Files

- `docs/dutch/adr/0002-turkish-prose-quoted-english.md` — new, the #84 decision.
- `docs/dutch/adr/0001-the-profile-is-public.md` — rescued from a local branch.
- `docs/dutch/CONTEXT.md` — **Bridge** and **Trap** added; **Lesson** and **Item** amended.

Documents only. No source file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)