### PR TITLE
docs(dutch): speaking is out of scope, and listening rests on human audio

### DIFF
--- a/docs/dutch/CONTEXT.md
+++ b/docs/dutch/CONTEXT.md
@@ -2,6 +2,8 @@
 
 A repo-native, agent-run Dutch practice aimed at Staatsexamen NT2, published on the site. The vocabulary below is this context's ubiquitous language: these words appear in the skill, in Astro schemas, in URLs, and in every conversation about the work. Taxonomy locked by [#82](https://github.com/atilileri/atilileri.github.io/issues/82); the language rule by [#84](https://github.com/atilileri/atilileri.github.io/issues/84); provenance by [#94](https://github.com/atilileri/atilileri.github.io/issues/94); the map is [#74](https://github.com/atilileri/atilileri.github.io/issues/74).
 
+**Three skills, not four.** This journey teaches *lezen*, *schrijven* and *luisteren*, plus KNM. **Spreken** is a word the Plan uses and the system does not teach: nothing here judges an accent, so the speaking Objectives sit in the Plan marked `unsupported` and are never selected. Listening rests on human recordings only; generated speech is unused. Locked by [#95](https://github.com/atilileri/atilileri.github.io/issues/95) and recorded in [`adr/0008-speaking-is-out-of-scope.md`](./adr/0008-speaking-is-out-of-scope.md).
+
 ## Language
 
 **Lesson**:

--- a/docs/dutch/adr/0008-speaking-is-out-of-scope.md
+++ b/docs/dutch/adr/0008-speaking-is-out-of-scope.md
@@ -1,0 +1,99 @@
+# ADR 0008 — Speaking is out of scope; listening rests on human audio only
+
+**Status**: Accepted
+**Date**: 2026-09-06
+**Scope**: `docs/dutch` — the Plan, every Lesson, every Session, and the skill that
+writes them
+**Spec**: [#95](https://github.com/atilileri/atilileri.github.io/issues/95), under map [#74](https://github.com/atilileri/atilileri.github.io/issues/74)
+
+## Context
+
+Staatsexamen NT2 tests four skills. Research
+[#77](https://github.com/atilileri/atilileri.github.io/issues/77) confirmed that
+*spreken* and *luisteren* are real components of Programma I, and research
+[#78](https://github.com/atilileri/atilileri.github.io/issues/78) then surveyed every
+teaching technique worth building and found that **not one of them reaches either
+skill** — all of them are text. #77 recommended ruling speaking out rather than
+faking coverage. The learner asked that we look for alternatives first, so this
+ticket looked.
+
+**The two skills are not the same problem.** Listening needs input the learner
+consumes, and input is findable. Speaking needs output somebody judges, and the
+judge is the missing piece.
+
+What the search found, measured rather than assumed:
+
+- [#96](https://github.com/atilileri/atilileri.github.io/issues/96) landed **74 hours
+  of Dutch audio** from five sources, and the learner captured the **DUO practice
+  exams for 2023, 2024 and 2025** by hand — all four skills, both programmes,
+  including **six real spreken papers with prompts and marking schemes**.
+- [#133](https://github.com/atilileri/atilileri.github.io/issues/133) installed local
+  speech recognition that recovers **96.1% of words** against a human transcript, at
+  about four times realtime, with no key and no network.
+- [#129](https://github.com/atilileri/atilileri.github.io/issues/129) measured Dutch
+  **speech synthesis** running locally for nothing — 21 times realtime, CC0 voice
+  data — but the one voice it measured is *"finetuned from a U.S. English lessac
+  voice"*, and nobody has listened to it.
+- The browser's `SpeechRecognition` was started here against `nl-NL`. It produced
+  **no result and no error**. Open-source Chromium carries the API without a
+  backend, so the route can never be verified from this machine — only on the
+  learner's own device, one vendor at a time.
+- [#96](https://github.com/atilileri/atilileri.github.io/issues/96) also found
+  **875,832 single-word Dutch recordings on Wikimedia Commons**, CC-licensed and
+  reachable with no key. Those are recordings of people.
+
+So a machine here can *hear* Dutch well and can *produce* Dutch sound cheaply.
+Neither fact supplies a judge of the learner's own accent, and none ever will.
+
+## Decision
+
+**This system teaches three skills plus KNM: lezen, schrijven and luisteren.
+Spreken is deliberately absent.**
+
+**Listening is covered, on human recordings only.**
+
+- The material is the landed corpus, the DUO listening clips, and public links.
+- **Generated speech is not used anywhere in this journey.** The capability exists
+  and stays unused. A synthetic voice with an English ancestor is not a thing to
+  teach pronunciation with, and the cheaper honest option was already on the table.
+- **A single Dutch word may link a human recording from Wikimedia Commons**, by link
+  and never by copy.
+- **No bare link.** Every listening item carries at least three comprehension
+  questions in Turkish. #78 found retrieval beats exposure, so a link nobody answers
+  anything about is not practice.
+- **One public video is recommended after each Session**, with its three questions.
+- **A video is admissible only when the agent can read text about it.** Level and fit
+  are judged from that text. Frames never decide level.
+
+**Speaking is out of scope.**
+
+- Nothing here judges an accent, and nothing scores a spoken answer.
+- The six DUO marking schemes are **not** used to let the learner mark themselves.
+  A marking scheme with no marker is a criterion the learner applies to their own ear,
+  which is the ear in question.
+- **A Lesson still ends with a read-aloud passage and a two-role dialogue**, as
+  [#85](https://github.com/atilileri/atilileri.github.io/issues/85) locked. That is
+  text on a page. It claims no coverage, needs no audio, and needs no judge.
+- The learner covers speaking through **their own NT2 course**, outside this system.
+  They raise it when they want to; Docent does not prompt for it.
+
+## Consequences
+
+- **The Plan keeps its spreken Objectives, marked `unsupported`**, pointing here. The
+  exam has four skills and the Plan shows the route to the exam, so deleting them
+  would make the Plan look complete when it is not. The hole stays visible on
+  purpose.
+- **The risk this ADR buys off is false confidence.** #77 named it: partial coverage
+  before an exam can persuade a candidate they are ready for a component nobody has
+  ever assessed them on. Absence is legible; a fake score is not.
+- **The verdict does not depend on anything unbuilt.** Listening is covered by audio
+  that already exists on disk. No driver, no voice model and no listening test stands
+  between this decision and its truth.
+- **[#137](https://github.com/atilileri/atilileri.github.io/issues/137) loses its
+  purpose.** It asked a human to judge locally generated Dutch speech. With synthesis
+  ruled out, there is nothing to judge.
+- **The map's open *"Pronunciation correctness"* item closes without synthesis.** The
+  answer turned out to be *use a human recording*, not *verify a machine*.
+- **Reopening this needs a judge, not a better voice.** Better synthesis changes
+  nothing here. What would change it is something that can hear the learner and say
+  whether a Dutch speaker would understand them.


### PR DESCRIPTION
Resolves grilling [#95](https://github.com/atilileri/atilileri.github.io/issues/95), under map [#74](https://github.com/atilileri/atilileri.github.io/issues/74).

Two files. Both are decisions, not code.

- **`docs/dutch/adr/0008-speaking-is-out-of-scope.md`** — the single source of the honest limit, so no later ticket re-litigates it. `0003` was taken, so it takes the next free number.
- **`docs/dutch/CONTEXT.md`** — a *Three skills, not four* note above the glossary. **No new vocabulary**: every decision in #95 uses terms the glossary already holds. What changed is a status, not a name.

## What #95 decided

**Listening is covered, on human recordings only.** #96's landed corpus, the DUO listening clips, and public links. **Generated speech is banned from the journey** — the capability is real and free (#129: Piper `nl_NL`, ~21x realtime, CC0) and stays unused, because the one measured voice is *"finetuned from a U.S. English lessac voice"* and a human recording was the cheaper honest route. Four rules bind every Session: no bare link, one public video per Session, a video is admissible only when the agent can read text about it, and every listening link says who can open it.

**Speaking is out of scope.** No judge, no score, no measurement. The Plan keeps its spreken Objectives marked `unsupported`, pointing at the ADR, so the hole in a four-skill exam stays visible. A Lesson still ends with #85's read-aloud passage and two-role dialogue — text on a page, claiming nothing.

## What was weighed and dropped

- **Word-level measurement of the learner's own voice** — memo to Drive, transcribed locally. Every part exists today. Whisper scored 96% on *native* podcast speech and would score far worse on accented learner Dutch, and a false miss teaches the learner to correct a word they said right. That is #77's false-confidence risk exactly.
- **Self-marking against the six real DUO marking schemes.** A scheme with no marker is a criterion the learner applies to their own ear, which is the ear in question.

## Follow-on

- Closes [#137](https://github.com/atilileri/atilileri.github.io/issues/137) — no generated speech left to judge.
- Closes the map's open *Pronunciation correctness* item, with *use a human recording* rather than *verify a machine*.
- Settles [#136](https://github.com/atilileri/atilileri.github.io/issues/136)'s client-side speech row.
- Spawns [#141](https://github.com/atilileri/atilileri.github.io/issues/141), the YouTube-understanding prototype.
- [#97](https://github.com/atilileri/atilileri.github.io/issues/97), [#87](https://github.com/atilileri/atilileri.github.io/issues/87) and [#131](https://github.com/atilileri/atilileri.github.io/issues/131) each carry the rules they inherit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)